### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,7 +1354,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A command-line interface for controlling La Marzocco espresso machines remotely"
 authors = ["Tim Rogers <me@timrogers.co.uk>"]


### PR DESCRIPTION
## Summary
• Update version from 0.1.0 to 0.1.1 in Cargo.toml and Cargo.lock for new release

## Test plan
- [ ] Verify version appears correctly in built binary
- [ ] Confirm all existing functionality works with new version
- [ ] Test package build process

🤖 Generated with [Claude Code](https://claude.ai/code)